### PR TITLE
Remove cost center tag 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Where applicable, the inputs will be checked against the RBA naming rules for Az
 |------|-------------|------|---------|:-----:|
 | additional\_tags | A map of additional tags to add to the tags output | `map(string)` | `{}` | no |
 | business\_unit | rba.businessUnit (https://github.com/openrba/python-azure-naming) | `string` | n/a | yes |
-| cost\_center | rba.costCenter (https://github.com/openrba/python-azure-naming) | `string` | n/a | yes |
 | environment | rba.environment (https://github.com/openrba/python-azure-naming) | `string` | n/a | yes |
 | location | rba.azureRegion (https://github.com/openrba/python-azure-naming) | `string` | n/a | yes |
 | market | rba.market (https://github.com/openrba/python-azure-naming) | `string` | n/a | yes |

--- a/data_sources.tf
+++ b/data_sources.tf
@@ -8,7 +8,6 @@ locals {
   valid_environment                  = can(local.naming_rules.environment.allowed_values[var.environment]) ? null : file("ERROR: invalid input value for environment")
   valid_location                     = can(local.naming_rules.azureRegion.allowed_values[var.location]) ? null : file("ERROR: invalid input value for location")
   valid_market                       = can(local.naming_rules.market.allowed_values[var.market]) ? null : file("ERROR: invalid input value for market")
-  valid_cost_center                  = can(local.naming_rules.costCenter.allowed_values[var.cost_center]) ? null : file("ERROR: invalid input value for cost_center")
   valid_subscription_type            = can(local.naming_rules.subscriptionType.allowed_values[var.subscription_type]) ? null : file("ERROR: invalid input value for subscription_type")
 
   # Validate optional inputs

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,6 @@ locals {
   tags = merge(
     {
       business_unit     = local.naming_rules.businessUnit.allowed_values[var.business_unit]
-      cost_center       = var.cost_center
       environment       = local.naming_rules.environment.allowed_values[var.environment]
       location          = local.naming_rules.azureRegion.allowed_values[var.location]
       market            = local.naming_rules.market.allowed_values[var.market]

--- a/variables.tf
+++ b/variables.tf
@@ -9,11 +9,6 @@ variable "business_unit" {
   type        = string
 }
 
-variable "cost_center" {
-  description = "rba.costCenter (https://github.com/openrba/python-azure-naming)"
-  type        = string
-}
-
 variable "environment" {
   description = "rba.environment (https://github.com/openrba/python-azure-naming)"
   type        = string


### PR DESCRIPTION
The cost_center tag is no longer mandatory on resources.
After a discussion with Charles Kaminski he only wants the cost_center tag on the subscription.

This change removes the cost_center tag from the input and output of this module.